### PR TITLE
Remove JSON.mapping in favor of JSON::Serializable.

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -6,7 +6,7 @@ description: |
 authors:
   - Igor Alexandrov <igor.alexandrov@gmail.com>
 
-crystal: 0.34
+crystal: 0.34.0
 
 license: MIT
 

--- a/spec/lib/storage/s3_spec.cr
+++ b/spec/lib/storage/s3_spec.cr
@@ -47,7 +47,7 @@ Spectator.describe Shrine::Storage::S3 do
   describe "#upload" do
     context "without `prefix`" do
       it "creates subdirectories" do
-        WebMock.stub(:put, "http://s3-us-east-2.amazonaws.com/test/object?")
+        WebMock.stub(:put, "https://s3-us-east-2.amazonaws.com/test/object?")
           .with(body: "", headers: {"Content-Type" => "binary/octet-stream"})
           .to_return(status: 200, body: "", headers: {"ETag" => "etag"})
 
@@ -61,7 +61,7 @@ Spectator.describe Shrine::Storage::S3 do
       let(prefix) { "prefix" }
 
       it "creates subdirectories" do
-        WebMock.stub(:put, "http://s3-us-east-2.amazonaws.com/test/#{prefix}/a/a/a.jpg?")
+        WebMock.stub(:put, "https://s3-us-east-2.amazonaws.com/test/#{prefix}/a/a/a.jpg?")
           .with(body: "", headers: {"Content-Type" => "binary/octet-stream"})
           .to_return(status: 200, body: "", headers: {"ETag" => "etag"})
 
@@ -73,7 +73,7 @@ Spectator.describe Shrine::Storage::S3 do
 
     context "with metadata" do
       it "file uploads" do
-        WebMock.stub(:put, "http://s3-us-east-2.amazonaws.com/test/a/a/a.jpg?")
+        WebMock.stub(:put, "https://s3-us-east-2.amazonaws.com/test/a/a/a.jpg?")
           .with(body: "", headers: {"Content-Type" => "binary/octet-stream", "Content-Disposition" => "inline; filename=\"ex\"; filename*=UTF-8''ex"})
           .to_return(status: 200, body: "", headers: {"ETag" => "etag"})
         response = subject.upload(FakeIO.new, "a/a/a.jpg", metadata)
@@ -87,7 +87,7 @@ Spectator.describe Shrine::Storage::S3 do
 
   describe "#exists?" do
     it "file exists" do
-      WebMock.stub(:head, "http://s3-us-east-2.amazonaws.com/test/a/a/a.jpg?")
+      WebMock.stub(:head, "https://s3-us-east-2.amazonaws.com/test/a/a/a.jpg?")
         .to_return(status: 200, headers: {"Content-Type" => "binary/octet-stream", "Last-Modified" => "Sun, 10 Jan 2020 4:47:46 UTC"})
       expect(
         subject.exists?("a/a/a.jpg")
@@ -95,7 +95,7 @@ Spectator.describe Shrine::Storage::S3 do
     end
 
     it "file does not exist" do
-      WebMock.stub(:head, "http://s3-us-east-2.amazonaws.com/test/ex.jpg?")
+      WebMock.stub(:head, "https://s3-us-east-2.amazonaws.com/test/ex.jpg?")
         .to_return(status: 404)
       expect(
         subject.exists?("ex.jpg")
@@ -125,7 +125,7 @@ Spectator.describe Shrine::Storage::S3 do
   describe "#open" do
     context "without `prefix`" do
       it "returns a IO-like object" do
-        WebMock.stub(:get, "http://s3-us-east-2.amazonaws.com/test/foo.jpg?")
+        WebMock.stub(:get, "https://s3-us-east-2.amazonaws.com/test/foo.jpg?")
           .to_return(body_io: FakeIO.new)
         expect(
           subject.open("foo.jpg")
@@ -135,7 +135,7 @@ Spectator.describe Shrine::Storage::S3 do
     context "with `prefix`" do
       let(prefix) { "prefix" }
       it "returns a IO-like object" do
-        WebMock.stub(:get, "http://s3-us-east-2.amazonaws.com/test/#{prefix}/foo.jpg?")
+        WebMock.stub(:get, "https://s3-us-east-2.amazonaws.com/test/#{prefix}/foo.jpg?")
           .to_return(body_io: FakeIO.new)
         expect(
           subject.open("foo.jpg")
@@ -147,7 +147,7 @@ Spectator.describe Shrine::Storage::S3 do
   describe "#delete" do
     context "without `prefix`" do
       it "deletes objects" do
-        WebMock.stub(:delete, "http://s3-us-east-2.amazonaws.com/test/foo.jpg?")
+        WebMock.stub(:delete, "https://s3-us-east-2.amazonaws.com/test/foo.jpg?")
           .to_return(status: 204)
         expect(
           subject.delete("foo.jpg")
@@ -158,7 +158,7 @@ Spectator.describe Shrine::Storage::S3 do
     context "with `prefix`" do
       let(prefix) { "prefix" }
       it "deletes objects" do
-        WebMock.stub(:delete, "http://s3-us-east-2.amazonaws.com/test/#{prefix}/foo.jpg?")
+        WebMock.stub(:delete, "https://s3-us-east-2.amazonaws.com/test/#{prefix}/foo.jpg?")
           .to_return(status: 204)
         expect(
           subject.delete("foo.jpg")

--- a/src/shrine/storage/s3.cr
+++ b/src/shrine/storage/s3.cr
@@ -30,12 +30,23 @@ class Shrine
       # :public
       # : Sets public access to all uploading files.
       #
-      def initialize(@bucket : String, @client : Awscr::S3::Client?, @prefix : String? = nil,
-                     @upload_options : Hash(String, String) = Hash(String, String).new, @public : Bool = false)
+      def initialize(
+        @bucket : String,
+        @client : Awscr::S3::Client?,
+        @prefix : String? = nil,
+        @upload_options : Hash(String, String) = Hash(String, String).new,
+        @public : Bool = false
+      )
       end
 
       # Copies the file into the given location.
-      def upload(io : IO, id : String, metadata : Shrine::UploadedFile::MetadataType? = nil, move = false, **upload_options)
+      def upload(
+        io : IO,
+        id : String,
+        metadata : Shrine::UploadedFile::MetadataType? = nil,
+        move = false,
+        **upload_options
+      )
         options = Hash(String, String).new
         options["Content-Disposition"] = ContentDisposition.inline(metadata["filename"].to_s) if metadata && metadata["filename"]
         options["x-amz-acl"] = "public-read" if public?

--- a/src/shrine/uploaded_file.cr
+++ b/src/shrine/uploaded_file.cr
@@ -2,26 +2,15 @@ require "json"
 
 class Shrine
   class UploadedFile
-    alias MetadataType = Hash(String, String | Int32 | UInt32 | Int64 | UInt64 | Nil)
+    include JSON::Serializable
 
-    # include JSON::Serializable
+    alias MetadataType = Hash(String, String | Int32 | UInt32 | Int64 | UInt64 | Nil)
 
     @io : IO?
 
-    JSON.mapping(
-      id: String,
-      storage_key: String,
-      metadata: MetadataType
-    )
-
-    # @[JSON::Field(key: "id")]
-    # property id : String
-
-    # @[JSON::Field(key: "storage_key")]
-    # property storage_key : String
-
-    # @[JSON::Field(key: "metadata")]
-    # property metadata : MetadataType
+    property id : String
+    property storage_key : String
+    property metadata : MetadataType
 
     def initialize(id : String, storage : String, metadata : MetadataType = MetadataType.new)
       @storage_key = storage


### PR DESCRIPTION
It was already in there, commented out, so I simpley re-enabled it. `JSON.mapping` will be deprecated in Crystal 0.35.0.

https://github.com/crystal-lang/crystal/pull/9272

Also corrected the Crystal version in shard.yml because 0.34 (instead of 0.34.0) raised an error for me.