### PR TITLE
Added first implemetation of `Shrine::Attacher`

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -21,12 +21,9 @@ dependencies:
   habitat:
     github: luckyframework/habitat
 
-
-
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 0.11.0
 
   spectator:
     gitlab: arctic-fox/spectator

--- a/spec/lib/attacher_spec.cr
+++ b/spec/lib/attacher_spec.cr
@@ -1,0 +1,682 @@
+require "../spec_helper"
+
+class Uploader < Shrine
+end
+
+Spectator.describe "Shrine::Attacher" do
+  include FileHelpers
+
+  let(attacher) {
+    Shrine::Attacher.new(**NamedTuple.new)
+  }
+
+  after_each do
+    clear_storages
+  end
+
+  describe ".shrine_class" do
+    it "returns `Shrine` for `Shrine::Attacher`" do
+      expect(
+        Shrine::Attacher.shrine_class
+      ).to eq(Shrine)
+    end
+
+    it "returns uploader class for `<uploader>::Attacher`" do
+      expect(
+        Uploader::Attacher.shrine_class
+      ).to eq(Uploader)
+    end
+  end
+
+  describe ".from_data" do
+    it "instantiates an attacher from file data" do
+      file = attacher.upload(fakeio)
+
+      expect(
+        Shrine::Attacher.from_data(file.data).file
+      ).to eq(file)
+    end
+
+    it "forwards additional options to .new" do
+      expect(
+        Shrine::Attacher.from_data(nil, cache_key: "other_cache").cache_key
+      ).to eq("other_cache")
+    end
+  end
+
+  describe "#assign" do
+    it "attaches a file to cache" do
+      attacher.assign(fakeio)
+      expect(attacher.file.not_nil!.storage_key).to eq("cache")
+    end
+
+    it "returns the cached file" do
+      file = attacher.assign(fakeio)
+
+      expect(file).to eq(attacher.file)
+    end
+
+    # it "ignores empty strings" do
+    #   attacher.assign(fakeio)
+    #   attacher.assign("")
+
+    #   expect(attacher.attached?).to be_true
+    # end
+
+    it "accepts nil" do
+      attacher.assign(fakeio)
+      attacher.assign(nil)
+
+      expect(attacher.attached?).to be_false
+    end
+
+    it "fowards any additional options for upload" do
+      attacher.assign(fakeio, location: "foo")
+
+      expect(attacher.file.not_nil!.id).to eq("foo")
+    end
+  end
+
+  describe "#attach_cached" do
+    context "with IO | Shrine::UploadedFile object" do
+      it "caches an IO object" do
+        attacher.attach_cached(fakeio)
+
+        expect(attacher.file.not_nil!.storage_key).to eq("cache")
+      end
+
+      it "caches an UploadedFile object" do
+        cached_file = Shrine.upload(fakeio, "cache")
+        attacher.attach_cached(cached_file)
+
+        expect(attacher.file.not_nil!.id).to_not eq(cached_file.id)
+      end
+
+      it "returns the attached file" do
+        file = attacher.attach_cached(fakeio)
+
+        expect(file).to eq(attacher.file)
+      end
+
+      context "with custom attacher options" do
+        let(attacher) {
+          Shrine::Attacher.new(cache_key: "other_cache")
+        }
+
+        it "uploads to attacher's temporary storage" do
+          attacher.attach_cached(fakeio)
+          expect(attacher.file.not_nil!.storage_key).to eq("other_cache")
+        end
+      end
+
+      it "accepts nils" do
+        attacher.attach_cached(fakeio)
+        attacher.attach_cached(nil)
+
+        expect(attacher.file).to be_nil
+      end
+
+      it "forwards additional options for upload" do
+        attacher.attach_cached(fakeio, location: "foo")
+
+        expect(attacher.file.not_nil!.id).to eq("foo")
+      end
+    end
+
+    context "with uploaded file data" do
+      it "accepts JSON data of a cached file" do
+        cached_file = Shrine.upload(fakeio, "cache")
+        attacher.attach_cached(cached_file.to_json)
+
+        expect(attacher.file).to eq(cached_file)
+      end
+
+      it "accepts Hash data of a cached file" do
+        cached_file = Shrine.upload(fakeio, "cache")
+        attacher.attach_cached(cached_file.data)
+
+        expect(attacher.file).to eq(cached_file)
+      end
+
+      it "changes the attachment" do
+        cached_file = Shrine.upload(fakeio, "cache")
+        attacher.attach_cached(cached_file.data)
+
+        expect(attacher.changed?).to be_true
+      end
+
+      it "returns the attached file" do
+        cached_file = Shrine.upload(fakeio, "cache")
+
+        expect(attacher.attach_cached(cached_file.data)).to eq(cached_file)
+      end
+
+      context "with custom attacher options" do
+        let(attacher) {
+          Shrine::Attacher.new(cache_key: "other_cache")
+        }
+
+        it "uses attacher's temporary storage" do
+          cached_file = Shrine.upload(fakeio, "other_cache")
+          attacher.attach_cached(cached_file.data)
+
+          expect(attacher.file.not_nil!.storage_key).to eq("other_cache")
+        end
+      end
+
+      it "rejects non-cached files" do
+        stored_file = Shrine.upload(fakeio, "store")
+
+        expect { attacher.attach_cached(stored_file.data) }.to raise_error(Shrine::NotCached)
+      end
+    end
+  end
+
+  describe "#attach" do
+    it "uploads the file to permanent storage" do
+      attacher.attach(fakeio)
+
+      expect(attacher.file.not_nil!.exists?).to be_true
+      expect(attacher.file.not_nil!.storage_key).to eq("store")
+    end
+
+    context "with custom attacher options" do
+      let(attacher) {
+        Shrine::Attacher.new(store_key: "other_cache")
+      }
+
+      it "uploads the file to permanent storage" do
+        attacher.attach(fakeio)
+
+        expect(attacher.file.not_nil!.exists?).to be_true
+        expect(attacher.file.not_nil!.storage_key).to eq("other_cache")
+      end
+    end
+
+    it "allows specifying a different storage" do
+      attacher.attach(fakeio, "other_store")
+
+      expect(attacher.file.not_nil!.exists?).to be_true
+      expect(attacher.file.not_nil!.storage_key).to eq("other_store")
+    end
+
+    it "forwards additional options for upload" do
+      attacher.attach(fakeio, location: "foo")
+
+      expect(attacher.file.not_nil!.id).to eq("foo")
+    end
+
+    it "returns the uploaded file" do
+      file = attacher.attach(fakeio)
+
+      expect(attacher.file).to eq(file)
+    end
+
+    it "changes the attachment" do
+      attacher.attach(fakeio)
+
+      expect(attacher.changed?).to be_true
+    end
+
+    it "accepts nil" do
+      attacher.attach(fakeio)
+      attacher.attach(nil)
+
+      expect(attacher.file).to be_nil
+    end
+  end
+
+  describe "#finalize" do
+    it "promotes cached file" do
+      attacher.attach_cached(fakeio)
+      attacher.finalize
+
+      expect(attacher.file.not_nil!.storage_key).to eq("store")
+    end
+
+    it "deletes previous file" do
+      previous_file = attacher.attach(fakeio)
+      attacher.attach(fakeio)
+      attacher.finalize
+
+      expect(previous_file.not_nil!.exists?).to be_false
+    end
+
+    it "clears dirty state" do
+      attacher.attach(fakeio)
+      attacher.finalize
+
+      expect(attacher.changed?).to be_false
+    end
+  end
+
+  describe "#promote_cached" do
+    it "uploads cached file to permanent storage" do
+      attacher.attach_cached(fakeio)
+      attacher.promote_cached
+
+      expect(attacher.file.not_nil!.storage_key).to eq("store")
+    end
+
+    it "doesn't promote if file is not cached" do
+      file = attacher.attach(fakeio, storage: "other_store")
+      attacher.promote_cached
+
+      expect(attacher.file).to eq(file)
+    end
+
+    it "doesn't promote if attachment has not changed" do
+      file = Shrine.upload(fakeio, "cache")
+      attacher.file = file
+      attacher.promote_cached
+
+      expect(attacher.file).to eq(file)
+    end
+
+    it "forwards additional options for upload" do
+      attacher.attach_cached(fakeio)
+      attacher.promote_cached(location: "foo")
+
+      expect(attacher.file.not_nil!.id).to eq("foo")
+    end
+  end
+
+  describe "#promote" do
+    it "uploads attached file to permanent storage" do
+      attacher.attach_cached(fakeio)
+      attacher.promote
+
+      expect(attacher.file.not_nil!.storage_key).to eq("store")
+      expect(attacher.file.not_nil!.exists?).to be_true
+    end
+
+    it "returns the promoted file" do
+      attacher.attach_cached(fakeio)
+      file = attacher.promote
+
+      expect(attacher.file).to eq(file)
+    end
+
+    it "allows uploading to a different storage" do
+      attacher.attach(fakeio)
+      attacher.promote(storage: "other_store")
+
+      expect(attacher.file.not_nil!.storage_key).to eq("other_store")
+      expect(attacher.file.not_nil!.exists?).to be_true
+    end
+
+    it "forwards additional options for upload" do
+      attacher.attach_cached(fakeio)
+      attacher.promote(location: "foo")
+
+      expect(attacher.file.not_nil!.id).to eq("foo")
+    end
+
+    it "doesn't change the attachment" do
+      attacher.file = attacher.upload(fakeio)
+      attacher.promote
+
+      expect(attacher.changed?).to be_false
+    end
+  end
+
+  describe "#upload" do
+    it "uploads file to permanent storage" do
+      uploaded_file = attacher.upload(fakeio)
+
+      expect(uploaded_file).to be_a(Shrine::UploadedFile)
+      expect(uploaded_file.exists?).to be_true
+      expect(uploaded_file.storage_key).to eq("store")
+    end
+
+    it "uploads file to specified storage" do
+      uploaded_file = attacher.upload(fakeio, "other_store")
+
+      expect(uploaded_file.storage_key).to eq("other_store")
+    end
+
+    it "forwards additional options" do
+      uploaded_file = attacher.upload(fakeio, metadata: {"foo" => "bar"})
+
+      expect(uploaded_file.metadata["foo"]).to eq("bar")
+    end
+  end
+
+  describe "#destroy_previous" do
+    it "deletes previous attached file" do
+      previous_file = attacher.attach(fakeio)
+      attacher.attach(fakeio)
+      attacher.destroy_previous
+
+      expect(previous_file.not_nil!.exists?).to be_false
+      expect(attacher.file.not_nil!.exists?).to be_true
+    end
+
+    it "deletes only stored files" do
+      previous_file = attacher.attach_cached(fakeio)
+      attacher.attach(fakeio)
+      attacher.destroy_previous
+
+      expect(previous_file.not_nil!.exists?).to be_true
+      expect(attacher.file.not_nil!.exists?).to be_true
+    end
+
+    it "handles previous attachment being nil" do
+      attacher.attach(fakeio)
+      attacher.destroy_previous
+
+      expect(attacher.file.not_nil!.exists?).to be_true
+    end
+
+    it "skips when attachment hasn't changed" do
+      attacher.file = attacher.upload(fakeio)
+      attacher.destroy_previous
+
+      expect(attacher.file.not_nil!.exists?).to be_true
+    end
+  end
+
+  describe "#destroy_attached" do
+    it "deletes stored file" do
+      attacher.file = Shrine.upload(fakeio, "other_store")
+      attacher.destroy_attached
+
+      expect(attacher.file.not_nil!.exists?).to be_false
+    end
+
+    it "doesn't delete cached files" do
+      attacher.file = Shrine.upload(fakeio, "cache")
+      attacher.destroy_attached
+
+      expect(attacher.file.not_nil!.exists?).to be_true
+    end
+
+    it "handles no attached file" do
+      expect { attacher.destroy_attached }.to_not raise_error
+    end
+  end
+
+  describe "#destroy" do
+    it "deletes attached file" do
+      attacher.file = attacher.upload(fakeio)
+
+      expect { attacher.destroy }.to_not raise_error
+    end
+
+    it "handles no attached file" do
+      expect { attacher.destroy }.to_not raise_error
+    end
+  end
+
+  describe "#change" do
+    it "sets the uploaded file" do
+      file = attacher.upload(fakeio)
+      attacher.change(file)
+
+      expect(attacher.file).to eq(file)
+    end
+
+    it "returns the uploaded file" do
+      file = attacher.upload(fakeio)
+
+      expect(attacher.change(file)).to eq(file)
+    end
+
+    it "marks attacher as changed" do
+      file = attacher.upload(fakeio)
+      attacher.change(file)
+
+      expect(attacher.changed?).to be_true
+    end
+
+    it "doesn't mark attacher as changed on same file" do
+      attacher.file = attacher.upload(fakeio)
+      attacher.change(attacher.file)
+
+      expect(attacher.changed?).to be_false
+    end
+  end
+
+  describe "#set" do
+    it "sets the uploaded file" do
+      file = attacher.upload(fakeio)
+      attacher.set(file)
+
+      expect(attacher.file).to eq(file)
+    end
+
+    it "returns the set file" do
+      file = attacher.upload(fakeio)
+
+      expect(attacher.set(file)).to eq(file)
+    end
+
+    it "doesn't mark attacher as changed" do
+      attacher.set attacher.upload(fakeio)
+
+      expect(attacher.changed?).to be_false
+    end
+  end
+
+  describe "#get" do
+    it "returns the attached file" do
+      attacher.attach(fakeio)
+
+      expect(attacher.get).to eq(attacher.file)
+    end
+
+    it "returns nil when no file is attached" do
+      expect(attacher.get).to be_nil
+    end
+  end
+
+  describe "#url" do
+    it "returns the attached file URL" do
+      attacher.attach(fakeio)
+
+      expect(attacher.url).to eq(attacher.file.not_nil!.url)
+    end
+
+    it "returns nil when no file is attached" do
+      expect(attacher.url).to be_nil
+    end
+  end
+
+  describe "changed?" do
+    it "returns true when the attachment has changed to another file" do
+      attacher.attach(fakeio)
+
+      expect(attacher.changed?).to be_true
+    end
+
+    it "returns true when the attachment has changed to nil" do
+      attacher.file = attacher.upload(fakeio)
+      attacher.attach(nil)
+
+      expect(attacher.changed?).to be_true
+    end
+
+    it "returns false when attachment hasn't changed" do
+      attacher.file = attacher.upload(fakeio)
+
+      expect(attacher.changed?).to be_false
+    end
+  end
+
+  describe "#attached?" do
+    it "returns true when file is attached" do
+      attacher.attach(fakeio)
+
+      expect(attacher.attached?).to be_true
+    end
+
+    it "returns false when file is not attached" do
+      expect(attacher.attached?).to be_false
+
+      attacher.attach(nil)
+
+      expect(attacher.attached?).to be_false
+    end
+  end
+
+  describe "#cached?" do
+    it "returns true when attached file is present and cached" do
+      attacher.file = Shrine.upload(fakeio, "cache")
+
+      expect(attacher.cached?).to eq(true)
+    end
+
+    it "returns true when specified file is present and cached" do
+      expect(attacher.cached?(Shrine.upload(fakeio, "cache"))).to be_true
+    end
+
+    it "returns false when attached file is present and stored" do
+      attacher.file = Shrine.upload(fakeio, "store")
+
+      expect(attacher.cached?).to be_false
+    end
+
+    it "returns false when specified file is present and stored" do
+      expect(attacher.cached?(Shrine.upload(fakeio, "store"))).to be_false
+    end
+
+    it "returns false when no file is attached" do
+      expect(attacher.cached?).to be_false
+    end
+
+    it "returns false when specified file is nil" do
+      expect(attacher.cached?(nil)).to be_false
+    end
+  end
+
+  describe "#stored?" do
+    it "returns true when attached file is present and stored" do
+      attacher.file = Shrine.upload(fakeio, "store")
+
+      expect(attacher.stored?).to be_true
+    end
+
+    it "returns true when specified file is present and stored" do
+      expect(attacher.stored?(Shrine.upload(fakeio, "store"))).to be_true
+    end
+
+    it "returns false when attached file is present and cached" do
+      attacher.file = Shrine.upload(fakeio, "cache")
+
+      expect(attacher.stored?).to be_false
+    end
+
+    it "returns false when specified file is present and cached" do
+      expect(attacher.stored?(Shrine.upload(fakeio, "cache"))).to be_false
+    end
+
+    it "returns false when no file is attached" do
+      expect(attacher.stored?).to be_false
+    end
+
+    it "returns false when specified file is nil" do
+      expect(attacher.stored?(nil)).to be_false
+    end
+  end
+
+  describe "#data" do
+    it "returns file data when file is attached" do
+      file = attacher.attach(fakeio)
+
+      expect(attacher.data).to eq(file.not_nil!.data)
+    end
+
+    it "returns nil when no file is attached" do
+      expect(attacher.data).to be_nil
+    end
+  end
+
+  describe "#load_data" do
+    it "loads file from given file data" do
+      file = attacher.upload(fakeio)
+      attacher.load_data(file.data)
+
+      expect(attacher.file).to eq(file)
+    end
+
+    it "handles NamedTuple" do
+      file = attacher.upload(fakeio)
+      attacher.load_data(
+        id: file.id,
+        storage_key: file.storage_key,
+        metadata: file.metadata,
+      )
+
+      expect(attacher.file).to eq(file)
+    end
+
+    it "clears file when given data is nil" do
+      attacher.file = attacher.upload(fakeio)
+      attacher.load_data(nil)
+
+      expect(attacher.file).to be_nil
+    end
+  end
+
+  describe "#file=" do
+    it "sets the file" do
+      file = attacher.upload(fakeio)
+      attacher.file = file
+
+      expect(attacher.file).to eq(file)
+    end
+
+    it "accepts nil" do
+      attacher.attach(fakeio)
+      attacher.file = nil
+
+      expect(attacher.file).to be_nil
+    end
+  end
+
+  describe "#file" do
+    it "returns set file" do
+      file = attacher.upload(fakeio)
+      attacher.file = file
+
+      expect(attacher.file).to eq(file)
+    end
+
+    it "returns nil when no file is set" do
+      expect(attacher.file).to be_nil
+    end
+  end
+
+  describe "#file!" do
+    it "returns set file" do
+      file = attacher.upload(fakeio)
+      attacher.file = file
+
+      expect(attacher.file!).to eq(file)
+    end
+
+    it "raises exception" do
+      expect { attacher.file! }.to raise_error(Shrine::Error)
+    end
+  end
+
+  describe "#upload_file" do
+    it "instantiates an uploaded file with JSON data" do
+      file = attacher.upload(fakeio)
+
+      expect(attacher.uploaded_file(file.to_json)).to eq(file)
+    end
+
+    it "instantiates an uploaded file with Hash data" do
+      file = attacher.upload(fakeio)
+
+      expect(attacher.uploaded_file(file.data)).to eq(file)
+    end
+
+    it "returns file with UploadedFile" do
+      file = attacher.upload(fakeio)
+
+      expect(attacher.uploaded_file(file)).to eq(file)
+    end
+  end
+end

--- a/spec/lib/plugins/add_metadata_spec.cr
+++ b/spec/lib/plugins/add_metadata_spec.cr
@@ -1,8 +1,5 @@
 require "../../spec_helper"
 
-class UploadedFileWithMetadata
-end
-
 class ShrineWithAddMetadata < Shrine
   load_plugin Shrine::Plugins::AddMetadata
 

--- a/spec/lib/plugins/column_spec.cr
+++ b/spec/lib/plugins/column_spec.cr
@@ -1,0 +1,104 @@
+require "../../spec_helper"
+
+require "yaml"
+
+class YamlSerializer < Shrine::Plugins::Column::BaseSerializer
+  def self.dump(data)
+    data.try &.to_yaml
+  end
+
+  def self.load(data)
+    Hash(String, String | Shrine::UploadedFile::MetadataType).from_yaml(data)
+  end
+end
+
+class ShrineWithColumn < Shrine
+  load_plugin(Shrine::Plugins::Column)
+
+  finalize_plugins!
+end
+
+class ShrineWithColumnAndYamlSerializer < Shrine
+  load_plugin(Shrine::Plugins::Column, column_serializer: YamlSerializer)
+
+  finalize_plugins!
+end
+
+Spectator.describe Shrine::Plugins::Column do
+  include FileHelpers
+
+  let(attacher) {
+    ShrineWithColumn::Attacher.new(**NamedTuple.new)
+  }
+
+  describe ".from_column" do
+    it "loads file from column data" do
+      file = attacher.upload(fakeio)
+      attacher = ShrineWithColumn::Attacher.from_column(file.to_json)
+
+      expect(attacher.file).to eq(file)
+    end
+
+    it "forwards additional options to .new" do
+      expect(
+        ShrineWithColumn::Attacher.from_column(nil, cache_key: "other_cache").cache_key
+      ).to eq("other_cache")
+    end
+  end
+
+  describe "#initialize" do
+    it "accepts a serializer" do
+      attacher = ShrineWithColumn::Attacher.new(column_serializer: YamlSerializer)
+
+      expect(attacher.column_serializer).to eq(YamlSerializer)
+    end
+
+    it "uses plugin serializer as default" do
+      expect(ShrineWithColumnAndYamlSerializer::Attacher.new.column_serializer).to eq(YamlSerializer)
+    end
+  end
+
+  describe "#load_column" do
+    it "loads file from serialized file data" do
+      file = attacher.upload(fakeio)
+      attacher.load_column(file.to_json)
+
+      expect(attacher.file).to eq(file)
+    end
+
+    it "clears file when nil is given" do
+      attacher.attach(fakeio)
+      attacher.load_column(nil)
+
+      expect(attacher.file).to be_nil
+    end
+
+    it "uses custom serializer" do
+      attacher = ShrineWithColumn::Attacher.new(column_serializer: YamlSerializer)
+
+      file = attacher.upload(fakeio)
+      attacher.load_column(file.data.to_yaml)
+
+      expect(attacher.file).to eq(file)
+    end
+  end
+
+  describe "#column_data" do
+    it "returns serialized file data" do
+      attacher.attach(fakeio)
+
+      expect(attacher.column_data).to eq(attacher.file.to_json)
+    end
+
+    it "returns nil when no file is attached" do
+      expect(attacher.column_data).to be_nil
+    end
+
+    it "uses custom serializer" do
+      attacher = ShrineWithColumn::Attacher.new(column_serializer: YamlSerializer)
+      attacher.attach(fakeio)
+
+      expect(attacher.column_data).to eq(attacher.file.not_nil!.data.to_yaml)
+    end
+  end
+end

--- a/spec/lib/storage/file_system_spec.cr
+++ b/spec/lib/storage/file_system_spec.cr
@@ -5,12 +5,6 @@ require "../../spec_helper"
 Spectator.describe Shrine::Storage::FileSystem do
   include FileHelpers
 
-  # class FileStorage < Shrine::Storage::FileSystem
-  #   def directory
-  #     root
-  #   end
-  # end
-
   subject {
     Shrine::Storage::FileSystem.new(
       directory: root,
@@ -18,14 +12,6 @@ Spectator.describe Shrine::Storage::FileSystem do
       permissions: permissions,
       directory_permissions: directory_permissions
     )
-  # Shrine::Storage::FileSystem.configure do |settings|
-  #   settings.directory = root
-  #   settings.prefix = prefix
-  #   settings.permissions = permissions
-  #   settings.directory_permissions = directory_permissions
-  # end
-
-  # Shrine::Storage::FileSystem.new
   }
 
   let(root) { File.join(Dir.tempdir, "shrine") }

--- a/spec/lib/uploaded_file_spec.cr
+++ b/spec/lib/uploaded_file_spec.cr
@@ -5,7 +5,7 @@ Spectator.describe Shrine::UploadedFile do
   include FileHelpers
 
   subject(uploaded_file) {
-    Shrine::UploadedFile.new(id, :cache, metadata)
+    Shrine::UploadedFile.new(id, "cache", metadata)
   }
 
   let(id) { "foo" }
@@ -21,6 +21,10 @@ Spectator.describe Shrine::UploadedFile do
   let(filename) { nil }
   let(mime_type) { nil }
   let(size) { nil }
+
+  after_each do
+    clear_storages
+  end
 
   describe "#initialize" do
     it "initializes metadata if absent" do
@@ -369,9 +373,9 @@ Spectator.describe Shrine::UploadedFile do
     it "returns uploaded file data hash" do
       expect(uploaded_file.data).to eq(
         {
-          "id"       => id,
-          "storage"  => "cache",
-          "metadata" => metadata,
+          "id"          => id,
+          "storage_key" => "cache",
+          "metadata"    => metadata,
         }
       )
     end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -13,6 +13,15 @@ end
 Shrine.configure do |config|
   config.storages["cache"] = Shrine::Storage::Memory.new
   config.storages["store"] = Shrine::Storage::Memory.new
+  config.storages["other_cache"] = Shrine::Storage::Memory.new
+  config.storages["other_store"] = Shrine::Storage::Memory.new
 end
 
 Shrine.raise_if_missing_settings!
+
+def clear_storages
+  Shrine.settings.storages["cache"].as(Shrine::Storage::Memory).clear!
+  Shrine.settings.storages["store"].as(Shrine::Storage::Memory).clear!
+  Shrine.settings.storages["other_cache"].as(Shrine::Storage::Memory).clear!
+  Shrine.settings.storages["other_store"].as(Shrine::Storage::Memory).clear!
+end

--- a/src/shrine/attacher.cr
+++ b/src/shrine/attacher.cr
@@ -1,0 +1,357 @@
+# frozen_string_literal: true
+
+class Shrine
+  # Core class that handles attaching files. It uses Shrine and
+  # Shrine::UploadedFile objects internally.
+  class Attacher
+    # Returns the Shrine class that this attacher class is namespaced
+    # under.
+    class_getter shrine_class : Shrine.class = Shrine
+
+    module ClassMethods
+      # Initializes the attacher from a data hash generated from `Attacher#data`.
+      #
+      #     attacher = Attacher.from_data({ "id" => "...", "storage" => "...", "metadata" => { ... } })
+      #     attacher.file #=> #<Shrine::UploadedFile>
+      def from_data(data : Hash(String, String | UploadedFile::MetadataType)?, **options)
+        attacher = new(**options)
+        attacher.load_data(data)
+        attacher
+      end
+    end
+
+    module InstanceMethods
+      # Returns the attached uploaded file.
+      property file : Shrine::UploadedFile?
+
+      # Returns options that are automatically forwarded to the uploader.
+      # Can be modified with additional data.
+      getter :context
+
+      getter :cache_key
+      getter :store_key
+
+      @previous : Shrine::Attacher?
+
+      # Initializes the attached file, temporary and permanent storage.
+      def initialize(@file : Shrine::UploadedFile? = nil, @cache_key : String = "cache", @store_key : String = "store")
+        @file = file
+        @cache_key = cache_key
+        @store_key = store_key
+        @context = Hash(String, String).new
+      end
+
+      # Calls #attach_cached, but skips if value is an empty string (this is
+      # useful when the uploaded file comes from form fields). Forwards any
+      # additional options to #attach_cached.
+      #
+      #     attacher.assign(File.open(...))
+      #     attacher.assign(File.open(...), metadata: { "foo" => "bar" })
+      #
+      #     # ignores the assignment when a blank string is given
+      #     attacher.assign("")
+      def assign(value : IO?, **options)
+        # return if value == "" # skip empty hidden field
+
+        attach_cached(value, **options)
+      end
+
+      # Sets an existing cached file, or uploads an IO object to temporary
+      # storage and sets it via #attach. Forwards any additional options to
+      # #attach.
+      #
+      #     # upload file to temporary storage and set the uploaded file.
+      #     attacher.attach_cached(File.open(...))
+      #
+      #     # foward additional options to the uploader
+      #     attacher.attach_cached(File.open(...), metadata: { "foo" => "bar" })
+      #
+      #     # sets an existing cached file from JSON data
+      #     attacher.attach_cached("{\"id\":\"...\",\"storage\":\"cache\",\"metadata\ ":{...}}")
+      #
+      #     # sets an existing cached file from Hash data
+      #     attacher.attach_cached({ "id" => "...", "storage" => "cache", "metadata" => {} })
+      def attach_cached(value : IO | UploadedFile | Nil, **options)
+        attach(value, **options.merge(storage: cache_key, action: :cache))
+      end
+
+      def attach_cached(value : String | Hash(String, String | UploadedFile::MetadataType), **options)
+        change(cached(value, **options))
+      end
+
+      # Uploads given IO object and changes the uploaded file.
+      #
+      #     # uploads the file to permanent storage
+      #     attacher.attach(io)
+      #
+      #     # uploads the file to specified storage
+      #     attacher.attach(io, storage: :other_store)
+      #
+      #     # forwards additional options to the uploader
+      #     attacher.attach(io, upload_options: { "x-amz-acl": "public-read" }, metadata: { "foo" => "bar" })
+      #
+      #     # removes the attachment
+      #     attacher.attach(nil)
+      def attach(io : IO | Shrine::UploadedFile | Nil, storage = store_key, **options) : UploadedFile | Nil
+        file = upload(io, storage, **options) if io
+
+        change(file)
+      end
+
+      # Deletes any previous file and promotes newly attached cached file.
+      # It also clears any dirty tracking.
+      #
+      #     # promoting cached file
+      #     attacher.assign(io)
+      #     attacher.cached? #=> true
+      #     attacher.finalize
+      #     attacher.stored?
+      #
+      #     # deleting previous file
+      #     previous_file = attacher.file
+      #     previous_file.exists? #=> true
+      #     attacher.assign(io)
+      #     attacher.finalize
+      #     previous_file.exists? #=> false
+      #
+      #     # clearing dirty tracking
+      #     attacher.assign(io)
+      #     attacher.changed? #=> true
+      #     attacher.finalize
+      #     attacher.changed? #=> false
+      def finalize
+        destroy_previous
+        promote_cached
+        @previous = nil if changed?
+      end
+
+      # If a new cached file has been attached, uploads it to permanent storage.
+      # Any additional options are forwarded to #promote.
+      #
+      #     attacher.assign(io)
+      #     attacher.cached? #=> true
+      #     attacher.promote_cached
+      #     attacher.stored? #=> true
+      def promote_cached(**options)
+        promote(**options) if promote?
+      end
+
+      # Uploads current file to permanent storage and sets the stored file.
+      #
+      #     attacher.cached? #=> true
+      #     attacher.promote
+      #     attacher.stored? #=> true
+      def promote(storage = store_key, **options) : Shrine::UploadedFile | Nil
+        set upload(file.not_nil!, storage, **options.merge(action: :store)) if file
+      end
+
+      # Delegates to `Shrine.upload`, passing the #context.
+      #
+      #     # upload file to specified storage
+      #     attacher.upload(io, "store") #=> #<Shrine::UploadedFile>
+      #
+      #     # pass additional options for the uploader
+      #     attacher.upload(io, "store", metadata: { "foo" => "bar" })
+      def upload(io : IO | Shrine::UploadedFile, storage = store_key, **options) : Shrine::UploadedFile
+        # shrine_class.upload(io, storage, **context, **options)
+        shrine_class.upload(io, storage, **options)
+      end
+
+      # If a new file was attached, deletes previously attached file if any.
+      #
+      #     previous_file = attacher.file
+      #     attacher.attach(file)
+      #     attacher.destroy_previous
+      #     previous_file.exists? #=> false
+      def destroy_previous
+        @previous.not_nil!.destroy_attached if changed?
+      end
+
+      # Destroys the attached file if it exists and is uploaded to permanent
+      # storage.
+      #
+      #     attacher.file.exists? #=> true
+      #     attacher.destroy_attached
+      #     attacher.file.exists? #=> false
+      def destroy_attached
+        destroy if destroy?
+      end
+
+      # Destroys the attachment.
+      #
+      #     attacher.file.exists? #=> true
+      #     attacher.destroy
+      #     attacher.file.exists? #=> false
+      def destroy
+        file.try &.delete
+      end
+
+      # Returns attached file or raises an exception if no file is attached.
+      def file!
+        file || raise Error.new("no file is attached")
+      end
+
+      # Loads the uploaded file from data generated by `Attacher#data`.
+      #
+      #     attacher.file #=> nil
+      #     attacher.load_data({ "id" => "...", "storage" => "...", "metadata" => { ... } })
+      #     attacher.file #=> #<Shrine::UploadedFile>
+      def load_data(data : Hash(String, String | UploadedFile::MetadataType))
+        @file = uploaded_file(data)
+      end
+
+      def load_data(**data)
+        @file = uploaded_file(data.to_h.transform_keys { |key| key.to_s })
+      end
+
+      def load_data(data : Nil)
+        @file = nil
+      end
+
+      # Sets the uploaded file with dirty tracking, and runs validations.
+      #
+      #     attacher.change(uploaded_file)
+      #     attacher.file #=> #<Shrine::UploadedFile>
+      #     attacher.changed? #=> true
+      def change(file : Shrine::UploadedFile?) : Shrine::UploadedFile?
+        @previous = dup unless @file == file
+
+        set(file)
+      end
+
+      # Sets the uploaded file.
+      #
+      #     attacher.set(uploaded_file)
+      #     attacher.file #=> #<Shrine::UploadedFile>
+      #     attacher.changed? #=> false
+      def set(file : Shrine::UploadedFile?) : Shrine::UploadedFile?
+        @file = file
+      end
+
+      # Returns the attached file.
+      #
+      #     # when a file is attached
+      #     attacher.get #=> #<Shrine::UploadedFile>
+      #
+      #     # when no file is attached
+      #     attacher.get #=> nil
+      def get
+        file
+      end
+
+      # If a file is attached, returns the uploaded file URL, otherwise returns
+      # nil. Any options are forwarded to the storage.
+      #
+      #     attacher.file = file
+      #     attacher.url #=> "https://..."
+      #
+      #     attacher.file = nil
+      #     attacher.url #=> nil
+      def url(**options)
+        file.try &.url(**options)
+      end
+
+      # Returns whether the attachment has changed.
+      #
+      #     attacher.changed? #=> false
+      #     attacher.attach(file)
+      #     attacher.changed? #=> true
+      #
+      # TODO: This will work incorrect if `@previous` is nil
+      def changed?
+        !!@previous
+      end
+
+      # Returns whether a file is attached.
+      #
+      #     attacher.attach(io)
+      #     attacher.attached? #=> true
+      #
+      #     attacher.attach(nil)
+      #     attacher.attached? #=> false
+      def attached?
+        !!file
+      end
+
+      # Returns whether the file is uploaded to temporary storage.
+      #
+      #     attacher.cached?       # checks current file
+      #     attacher.cached?(file) # checks given file
+      def cached?(file = self.file)
+        uploaded?(file, cache_key)
+      end
+
+      # Returns whether the file is uploaded to permanent storage.
+      #
+      #     attacher.stored?       # checks current file
+      #     attacher.stored?(file) # checks given file
+      def stored?(file = self.file)
+        uploaded?(file, store_key)
+      end
+
+      # Generates serializable data for the attachment.
+      #
+      #     attacher.data #=> { "id" => "...", "storage" => "...", "metadata": { ... } }
+      def data
+        file.try &.data
+      end
+
+      # Converts JSON or Hash data into a Shrine::UploadedFile object.
+      #
+      #     attacher.uploaded_file("{\"id\":\"...\",\"storage\":\"...\",\"metadata\":{...}}")
+      #     #=> #<Shrine::UploadedFile ...>
+      #
+      #     attacher.uploaded_file({ "id" => "...", "storage" => "...", "metadata" => {} })
+      #     #=> #<Shrine::UploadedFile ...>
+      def uploaded_file(value)
+        shrine_class.uploaded_file(value)
+      end
+
+      # Returns the Shrine class that this attacher's class is namespaced
+      # under.
+      def shrine_class
+        self.class.shrine_class
+      end
+
+      # Converts a String or Hash value into an UploadedFile object and ensures
+      # it's uploaded to temporary storage.
+      #
+      #     # from JSON data
+      #     attacher.cached("{\"id\":\"...\",\"storage\":\"cache\",\"metadata\":{...}}")
+      #     #=> #<Shrine::UploadedFile>
+      #
+      #     # from Hash data
+      #     attacher.cached({ "id" => "...", "storage" => "cache", "metadata" => { ... } })
+      #     #=> #<Shrine::UploadedFile>
+      private def cached(value : String | Hash(String, String | UploadedFile::MetadataType), **options)
+        uploaded_file = uploaded_file(value)
+
+        # reject files not uploaded to temporary storage, because otherwise
+        # attackers could hijack other users' attachments
+        unless cached?(uploaded_file)
+          raise Shrine::NotCached.new "expected cached file, got #{uploaded_file.inspect}"
+        end
+
+        uploaded_file
+      end
+
+      # Whether attached file should be uploaded to permanent storage.
+      private def promote?
+        changed? && cached?
+      end
+
+      # Whether attached file should be deleted.
+      private def destroy?
+        attached? && !cached?
+      end
+
+      # Returns whether the file is uploaded to specified storage.
+      private def uploaded?(file, storage_key)
+        file.try &.storage_key == storage_key
+      end
+    end
+
+    extend ClassMethods
+    include InstanceMethods
+  end
+end

--- a/src/shrine/plugins/column.cr
+++ b/src/shrine/plugins/column.cr
@@ -1,0 +1,74 @@
+class Shrine
+  module Plugins
+    module Column
+      abstract class BaseSerializer
+        # Since we cannot make class level method abstract we raise NotImplementedError
+        # https://github.com/crystal-lang/crystal/issues/5956
+        #
+        def self.dump(data)
+          raise NotImplementedError.new("Implement method .dump")
+        end
+
+        def self.load(data)
+          raise NotImplementedError.new("Implement method .load")
+        end
+      end
+
+      class JsonSerializer < BaseSerializer
+        def self.dump(data)
+          data.try &.to_json
+        end
+
+        def self.load(data)
+          Hash(String, String | UploadedFile::MetadataType).from_json(data)
+        end
+      end
+
+      DEFAULT_OPTIONS = {
+        column_serializer: Shrine::Plugins::Column::JsonSerializer,
+      }
+
+      module AttacherClassMethods
+        # Initializes the attacher from a data hash/string expected to come
+        # from a database record column.
+        #
+        #     Attacher.from_column('{"id":"...","storage":"...","metadata":{...}}')
+        def from_column(data, **options) : Attacher | Nil
+          attacher = new(**options)
+          attacher.load_column(data)
+          attacher
+        end
+      end
+
+      module AttacherMethods
+        # Column serializer object.
+        getter column_serializer : Shrine::Plugins::Column::BaseSerializer.class
+
+        # Allows overriding the default column serializer.
+        def initialize(@column_serializer = self.class.shrine_class.plugin_settings.column[:column_serializer], **options)
+          super(**options)
+        end
+
+        # Loads attachment from column data.
+        #
+        #     attacher.file #=> nil
+        #     attacher.load_column('{"id":"...","storage":"...","metadata":{...}}')
+        #     attacher.file #=> #<Shrine::UploadedFile>
+        def load_column(data : String) : UploadedFile
+          load_data(column_serializer.load(data))
+        end
+
+        def load_column(data : Nil) : Nil
+          load_data(data)
+        end
+
+        # Returns attacher data as a serialized string (JSON by default).
+        #
+        #     attacher.column_data #=> '{"id":"...","storage":"...","metadata":{...}}'
+        def column_data : String | Nil
+          column_serializer.dump(data)
+        end
+      end
+    end
+  end
+end

--- a/src/shrine/plugins/determine_mime_type.cr
+++ b/src/shrine/plugins/determine_mime_type.cr
@@ -76,7 +76,7 @@ class Shrine
             io.rewind
             stdout.to_s.strip
           else
-            raise Error.new "file command failed: #{stderr.to_s}"
+            raise Error.new "file command failed: #{stderr}"
           end
         rescue RuntimeError
           raise Error.new("file command-line tool is not installed")

--- a/src/shrine/storage/base.cr
+++ b/src/shrine/storage/base.cr
@@ -6,7 +6,7 @@ class Shrine
       getter? clean : Bool = true
 
       # uploads `io` to the location `id`, can accept upload options
-      abstract def upload(io : IO, id : String, move = false, **options)
+      abstract def upload(io : IO | UploadedFile, id : String, move = false, **options)
 
       # returns the remote file as an IO-like object
       abstract def open(id : String, **options) : IO

--- a/src/shrine/storage/file_system.cr
+++ b/src/shrine/storage/file_system.cr
@@ -46,7 +46,7 @@ class Shrine
       end
 
       # Copies the file into the given location.
-      def upload(io : IO, id : String, move = false, **options)
+      def upload(io : IO | UploadedFile, id : String, move = false, **options)
         if move && movable?(io)
           move(io, path!(id))
         else

--- a/src/shrine/storage/memory.cr
+++ b/src/shrine/storage/memory.cr
@@ -9,7 +9,7 @@ class Shrine
         @store = {} of String => String
       end
 
-      def upload(io : IO, id : String, **options)
+      def upload(io : IO | UploadedFile, id : String, **options)
         store[id.to_s] = io.gets_to_end
       end
 


### PR DESCRIPTION
``` crystal
Shrine.configure do |config|
  config.storages["cache"] = Shrine::Storage::Memory.new
  config.storages["store"] = Shrine::Storage::Memory.new
end
```

``` crystal
file = File.open(File::NULL)
attacher.assign(file) # #<Shrine::UploadedFile:0x1074bbde0 @io=nil, @mapper=Shrine::UploadedFile::Mapper(@id="85f8698cd8cc9a110388229c65497d4d", @storage_key="cache", @metadata={"filename" => "null", "size" => 0, "mime_type" => nil})>
```

``` crystal
attacher.promote # #<Shrine::UploadedFile:0x1074bbde0 @io=nil, @mapper=Shrine::UploadedFile::Mapper(@id="85f8698cd8cc9a110388229c65497d4d", @storage_key="store", @metadata={"filename" => "null", "size" => 0, "mime_type" => nil})>
```