### PR TITLE
Add crystal 0.35.0 compatibility

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -6,7 +6,7 @@ description: |
 authors:
   - Igor Alexandrov <igor.alexandrov@gmail.com>
 
-crystal: 0.34.0
+crystal: 0.35.0
 
 license: MIT
 

--- a/shard.yml
+++ b/shard.yml
@@ -16,10 +16,13 @@ dependencies:
     version: ~> 0.8.0
   content_disposition:
     github: jetrockets/content_disposition.cr
+    version: ~> 1.1.1
   habitat:
     github: luckyframework/habitat
+    version: ~> 0.4.3
   pixie:
     github: watzon/pixie
+    branch: master
 
 development_dependencies:
   ameba:
@@ -27,6 +30,7 @@ development_dependencies:
     version: ~> 0.11.0
   spectator:
     gitlab: arctic-fox/spectator
+    version: ~> 0.9.20
   webmock:
     github: manastech/webmock.cr
     branch: master

--- a/src/shrine/storage/file_system.cr
+++ b/src/shrine/storage/file_system.cr
@@ -96,7 +96,7 @@ class Shrine
       protected def clean(path)
         Path[path].each_parent do |pathname|
           if Dir.empty?(pathname.to_s) && pathname != directory
-            Dir.rmdir(pathname.to_s)
+            Dir.delete(pathname.to_s)
           else
             break
           end


### PR DESCRIPTION
It looks like with Crystal 0.35.0 we need to define shard versions explicitly. Otherwise, installing shrine will raise the following error:

```bash
...
Fetching https://github.com/jetrockets/content_disposition.cr.git
git fetch --all --quiet
git tag --list --column=never
git ls-tree -r --full-tree --name-only refs/tags/v1.0.1 -- shard.yml
git show refs/tags/v1.0.1:shard.yml
in shard.yml: duplicate attribute: development_dependencies at line 15, column 1

  13.     gitlab: arctic-fox/spectator
  14. 
  15. development_dependencies:
...
```

That's because `v1.0.1` is pulled, and not the latest `v1.1.1`.

The other fix is using `Dir.delete` instead of `Dir.rmdir`, which is now deprecated.