### PR TITLE
Fix documentation errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,13 @@ end
 Now you can use `Shrine` directly to upload your files.
 
 ``` crystal
-Shrine.upload(file, :store)
+Shrine.upload(file, "store")
 ```
 
 `Shrine.upload` method supports additional argument just like Shrine.rb. For example we want our file to have a custom filename.
 
 ``` crystal
-Shrine.upload(file, :store, metadata: { filename: "foo.bar" })
+Shrine.upload(file, "store", metadata: { "filename" => "foo.bar" })
 ```
 
 ### Custom uploaders
@@ -67,7 +67,7 @@ class FileImport::AssetUploader < Shrine
   end
 end
 
-FileImport::AssetUploader.upload(file, :store, context: { model: YOUR_ORM_MODEL } })
+FileImport::AssetUploader.upload(file, "store", context: { model: YOUR_ORM_MODEL } })
 ```
 
 ### S3 storage


### PR DESCRIPTION
- The storage name must be a string (not calling `.to_s` anywhere) https://github.com/jetrockets/shrine.cr/blob/59e2293770b355466f7c4d88fe905caa5b995cf1/src/shrine.cr#L236
- metadata must be a Hash, not a NamedTuple https://github.com/jetrockets/shrine.cr/blob/59e2293770b355466f7c4d88fe905caa5b995cf1/src/shrine/uploaded_file.cr#L7