### PR TITLE
Crystal 0.36.0 support

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -13,8 +13,8 @@ license: MIT
 
 dependencies:
   awscr-s3:
-    github: taylorfinnell/awscr-s3
-    version: ~> 0.8.0
+    github: matthewmcgarvey/awscr-s3
+    branch: fix/86
   content_disposition:
     github: jetrockets/content_disposition.cr
     branch: master

--- a/shard.yml
+++ b/shard.yml
@@ -13,8 +13,8 @@ license: MIT
 
 dependencies:
   awscr-s3:
-    github: matthewmcgarvey/awscr-s3
-    branch: fix/86
+    github: taylorfinnell/awscr-s3
+    version: ~> 0.8.1
   content_disposition:
     github: jetrockets/content_disposition.cr
     branch: master

--- a/spec/shrine/storage/s3_spec.cr
+++ b/spec/shrine/storage/s3_spec.cr
@@ -77,7 +77,6 @@ Spectator.describe Shrine::Storage::S3 do
           .with(body: "", headers: {"Content-Type" => "binary/octet-stream", "Content-Disposition" => "inline; filename=\"ex\"; filename*=UTF-8''ex"})
           .to_return(status: 200, body: "", headers: {"ETag" => "etag"})
         response = subject.upload(FakeIO.new, "a/a/a.jpg", metadata)
-        p response
         expect(
           subject.upload(FakeIO.new, "a/a/a.jpg", metadata)
         ).to be_true

--- a/spec/shrine/uploaded_file_spec.cr
+++ b/spec/shrine/uploaded_file_spec.cr
@@ -65,26 +65,26 @@ Spectator.describe Shrine::UploadedFile do
 
     context "with extension in `id`" do
       let(id) { "foo.jpg" }
-      it is_expected.to eq("jpg")
+      it { is_expected.to eq("jpg") }
     end
 
     context "without extension in `id`" do
       let(id) { "foo" }
-      it is_expected.to be_nil
+      it { is_expected.to be_nil }
     end
 
     context "with filename and extension in `metadata`" do
       let(filename) { "foo.jpg" }
-      it is_expected.to eq("jpg")
+      it { is_expected.to eq("jpg") }
     end
 
     context "with filename in `metadata`" do
       let(filename) { "foo" }
-      it is_expected.to be_nil
+      it { is_expected.to be_nil }
     end
 
     context "without filename in `metadata`" do
-      it is_expected.to be_nil
+      it { is_expected.to be_nil }
     end
 
     context "with extension in `id` and in `metadata`" do

--- a/src/shrine/storage/memory.cr
+++ b/src/shrine/storage/memory.cr
@@ -9,7 +9,7 @@ class Shrine
         @store = {} of String => String
       end
 
-      def upload(io : IO | UploadedFile, id : String, **options)
+      def upload(io : IO | UploadedFile, id : String, move = false, **options)
         store[id.to_s] = io.gets_to_end
       end
 
@@ -18,6 +18,10 @@ class Shrine
         IO::Memory.new(store[id])
       rescue KeyError
         raise Shrine::FileNotFound.new("file #{id.inspect} not found on storage")
+      end
+
+      def open(id : String, **options) : IO
+        open(id)
       end
 
       def exists?(id : String) : Bool

--- a/src/shrine/storage/s3.cr
+++ b/src/shrine/storage/s3.cr
@@ -54,7 +54,7 @@ class Shrine
         uploader.upload(bucket, object_key(id), io, options)
       end
 
-      def upload(io : UploadedFile, id : String, move = false, **upload_options)
+      def upload(io : IO | UploadedFile, id : String, move = false, **upload_options)
         upload(io, id, **upload_options.merge(move: move))
       end
 


### PR DESCRIPTION
Spec changes are due to this issue https://github.com/icy-arctic-fox/spectator/issues/20

Code changes are because inheriting classes must completely implement abstract defs of parent classes.

Shard change is because the aws library does not support 0.36.0 until this pr is merged and a new version is released https://github.com/taylorfinnell/awscr-s3/pull/87