### PR TITLE
Get back to versioned awscr-s3 dependency

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -14,7 +14,7 @@ license: MIT
 dependencies:
   awscr-s3:
     github: taylorfinnell/awscr-s3
-    branch: master
+    version: ~> 0.8.2
   content_disposition:
     github: jetrockets/content_disposition.cr
     version: ~> 1.2.0


### PR DESCRIPTION
Now that it appears as though this dependency supports Crystal 1.0 (https://github.com/taylorfinnell/awscr-s3/pull/94), we should move back off of the master branch so that other libraries using specific versions won't conflict.