### PR TITLE
Make open return IO with data

### DIFF
--- a/src/shrine/storage/s3.cr
+++ b/src/shrine/storage/s3.cr
@@ -65,10 +65,10 @@ class Shrine
       def open(id : String, **options) : IO
         io = IO::Memory.new
         client.get_object(bucket, object_key(id)) do |obj|
-          io << obj
+          IO.copy(obj.body_io, io)
         end
 
-        # io
+        io
         # client.get_object(bucket, object_key(id)).body_io
       end
 


### PR DESCRIPTION
Using the open method now will return an empty IO. 
By copying the IO of the body to the IO and returning it, it will work.